### PR TITLE
To use cassandra as service on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,8 @@
 language: node_js
 node_js:
   - 'stable'
+sudo: required
+services:
+  - cassandra
 notifications:
   slack: bwekfastclub:apMLylCPCrM8rZTKlRkUOohL


### PR DESCRIPTION
Sudo access is required to use cassandra on travis